### PR TITLE
Fixed '$templateNames' variable name and type.

### DIFF
--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMProvisionOnlineInstance/MSCRMProvisionOnlineInstance.ps1
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMProvisionOnlineInstance/MSCRMProvisionOnlineInstance.ps1
@@ -63,21 +63,22 @@ if (-not $mscrmToolsPath)
 
 $PSModulePath = "$mscrmToolsPath\OnlineManagementAPI\1.0.0"
 
+$templateNames = [string[]] @()
 if ($sales)
 {
-    $templatesNames = "D365_Sales"
+    $templateNames += "D365_Sales"
 }
 if ($customerService)
 {
-    $templatesNames = $templatesNames += "D365_CustomerService"
+    $templateNames += "D365_CustomerService"
 }
 if ($fieldService)
 {
-    $templatesNames = $templatesNames += "D365_FieldService"
+    $templateNames += "D365_FieldService"
 }
 if ($projectService)
 {
-    $templatesNames = $templatesNames += "D365_ProjectServiceAutomation"
+    $templateNames += "D365_ProjectServiceAutomation"
 }
 
 


### PR DESCRIPTION
When trying to provision a new Dynamics instance, I noticed that the template check boxes were not working.
I think my change should fix the problem, but I haven't got a validated organization (yet) to add an extension to, so I was not able to test the fix.
The problems I tried to fix:
- The name of the variable that was initialized was different from the variable passed to the ProvisionOnlineInstance.ps1 script.
- The initialized variable was not a string array (but just a string).
