### PR TITLE
Added more Versioning options to MSCRMExportSolution

### DIFF
--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
@@ -36,7 +36,7 @@ $versionString = Get-VstsInput -Name versionString
 $buildNumber = $env:BUILD_BUILDNUMBER
 $sourcesDirectory = $env:BUILD_SOURCESDIRECTORY
 $binariesDirectory = $env:BUILD_BINARIESDIRECTORY
-$releaseName = $env:RELEASE_NAME
+$releaseName = $env:RELEASE_RELEASENAME
 
 #Print Verbose
 Write-Verbose "crmConnectionString = $crmConnectionString"

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
@@ -45,7 +45,6 @@ Write-Verbose "exportManaged = $exportManaged"
 Write-Verbose "exportUnmanaged = $exportUnmanaged"
 Write-Verbose "includeVersionInSolutionFile = $includeVersionInSolutionFile"
 Write-Verbose "targetVersion = $targetVersion"
-Write-Verbose "updateVersion = $updateVersion"
 Write-Verbose "includeVersionInSolutionFile = $includeVersionInSolutionFile"
 Write-Verbose "outputPath = $outputPath"
 Write-Verbose "crmConnectionTimeout = $crmConnectionTimeout"
@@ -65,14 +64,15 @@ Write-Verbose "buildNumber = $buildNumber"
 Write-Verbose "sourcesDirectory = $sourcesDirectory"
 Write-Verbose "binariesDirectory = $binariesDirectory"
 
-if ($updateVersion)
-{
+$updateVersion ="$versioning".ToUpperInvariant() -ne "NONE"
+if("$versioning".ToUpperInvariant() -eq "BUILDNUMBER") {
+    $splits = $buildNumber.Split("_")
+    $versionNumber = $splits[$splits.Count-1]
+} elseif("$versioning".ToUpperInvariant() -eq "RELEASENAME") {
+    $splits = $releaseName.Split("_")
+    $versionNumber = $splits[$splits.Count-1]
+} elseif("$versioning".ToUpperInvariant() -eq "MANUAL") {
     $versionNumber = $versionString
-    if($useBuildNumber)
-    {
-    	$splits = $buildNumber.Split("_")
-    	$versionNumber = $splits[$splits.Count-1]
-    }
 }
 
 #MSCRM Tools

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
@@ -29,14 +29,14 @@ $exportRelationshipRoles = Get-VstsInput -Name exportRelationshipRoles -AsBool
 $exportSales = Get-VstsInput -Name exportSales -AsBool
 
 # Versioning
-$updateVersion = Get-VstsInput -Name updateVersion -AsBool
-$useBuildNumber = Get-VstsInput -Name useBuildNumber -AsBool
-$versionString = Get-VstsInput -Name versionString -AsBool
+$versioning = Get-VstsInput -Name versioning
+$versionString = Get-VstsInput -Name versionString
 
 #TFS Build Parameters
 $buildNumber = $env:BUILD_BUILDNUMBER
 $sourcesDirectory = $env:BUILD_SOURCESDIRECTORY
 $binariesDirectory = $env:BUILD_BINARIESDIRECTORY
+$releaseName = $env:RELEASE_NAME
 
 #Print Verbose
 Write-Verbose "crmConnectionString = $crmConnectionString"

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
@@ -13,7 +13,6 @@ $exportManaged = Get-VstsInput -Name exportManaged -Require -AsBool
 $exportUnmanaged = Get-VstsInput -Name exportUnmanaged -Require -AsBool
 $includeVersionInSolutionFile = Get-VstsInput -Name includeVersionInSolutionFile -AsBool
 $targetVersion = Get-VstsInput -Name targetVersion
-$updateVersion = Get-VstsInput -Name updateVersion -AsBool
 $includeVersionInSolutionFile = Get-VstsInput -Name includeVersionInSolutionFile -AsBool
 $outputPath = Get-VstsInput -Name outputPath -Require
 $crmConnectionTimeout = Get-VstsInput -Name crmConnectionTimeout -Require -AsInt
@@ -28,6 +27,11 @@ $exportMarketingSettings = Get-VstsInput -Name exportMarketingSettings -AsBool
 $exportOutlookSynchronizationSettings = Get-VstsInput -Name exportOutlookSynchronizationSettings -AsBool
 $exportRelationshipRoles = Get-VstsInput -Name exportRelationshipRoles -AsBool
 $exportSales = Get-VstsInput -Name exportSales -AsBool
+
+# Versioning
+$updateVersion = Get-VstsInput -Name updateVersion -AsBool
+$useBuildNumber = Get-VstsInput -Name useBuildNumber -AsBool
+$versionString = Get-VstsInput -Name versionString -AsBool
 
 #TFS Build Parameters
 $buildNumber = $env:BUILD_BUILDNUMBER
@@ -63,8 +67,12 @@ Write-Verbose "binariesDirectory = $binariesDirectory"
 
 if ($updateVersion)
 {
-    $splits = $buildNumber.Split("_")
-    $versionNumber = $splits[$splits.Count-1]
+    $versionNumber = $versionString
+    if($useBuildNumber)
+    {
+    	$splits = $buildNumber.Split("_")
+    	$versionNumber = $splits[$splits.Count-1]
+    }
 }
 
 #MSCRM Tools

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
@@ -213,6 +213,7 @@
       "name": "versionString",
       "type": "string",
       "label": "Version String",
+      "visibleRule": "versioning = manual",
       "required": false,
       "helpMarkDown": "Sets the solution version explicitly",
       "groupName": "versioningOptions"

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
@@ -195,23 +195,20 @@
       "groupName": "exportOptions"
     },
     {
-      "name": "updateVersion",
-      "type": "boolean",
-      "label": "Update Version",
-      "defaultValue": "false",
+      "name": "versioning",
+      "type": "radio",
+      "label": "Versioning",
       "required": false,
-      "helpMarkDown": "Set the solution version in the source environment.",
-      "groupName": "versioningOptions"
-    },
-    {
-      "name": "useBuildNumber",
-      "type": "boolean",
-      "label": "User Build Number",
-      "defaultValue": "false",
-      "required": false,
-      "helpMarkDown": "Sets the solution version in the source environment to the build number. build number format must end with '_x.x.x.x' e.g. '$(BuildDefinitionName)_5.0.0$(Rev:.r)'",
-      "groupName": "versioningOptions"
-    },
+      "defaultValue": "none",
+      "helpMarkDown": "Defines whether and how the solution version on the source environment should be updated.",
+      "groupName": "versioningOptions",
+      "options": {
+          "none": "None",
+          "buildnumber": "Build Number",
+          "releasename": "Release Name",
+          "manual": "Manual"
+      },
+    },   
     {
       "name": "versionString",
       "type": "string",

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
@@ -23,6 +23,11 @@
       "name": "exportOptions",
       "displayName": "Additional Export Options",
       "isExpanded": false
+    },
+    {
+      "name": "versioningOptions",
+      "displayName": "Versioning Options",
+      "isExpanded": false
     }
   ],
   "inputs": [
@@ -65,14 +70,6 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Check task help for more information"
-    },
-    {
-      "name": "updateVersion",
-      "type": "boolean",
-      "label": "Update Version",
-      "defaultValue": "false",
-      "required": false,
-      "helpMarkDown": "Sets the solution version in the source environment to the build number. build number format must end with '_x.x.x.x' e.g. '$(BuildDefinitionName)_5.0.0$(Rev:.r)'"
     },
     {
       "name": "includeVersionInSolutionFile",
@@ -196,6 +193,32 @@
       "required": false,
       "helpMarkDown": "Check task help for more information",
       "groupName": "exportOptions"
+    },
+    {
+      "name": "updateVersion",
+      "type": "boolean",
+      "label": "Update Version",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Set the solution version in the source environment.",
+      "groupName": "versioningOptions"
+    },
+    {
+      "name": "useBuildNumber",
+      "type": "boolean",
+      "label": "User Build Number",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Sets the solution version in the source environment to the build number. build number format must end with '_x.x.x.x' e.g. '$(BuildDefinitionName)_5.0.0$(Rev:.r)'",
+      "groupName": "versioningOptions"
+    },
+    {
+      "name": "versionString",
+      "type": "string",
+      "label": "Version String",
+      "required": false,
+      "helpMarkDown": "Sets the solution version explicitly",
+      "groupName": "versioningOptions"
     }
   ],
   "execution": {

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMExportSolution/task.json
@@ -12,7 +12,7 @@
   ],
   "demands": [ ],
   "version": {
-    "Major": "10",
+    "Major": "11",
     "Minor": "0",
     "Patch": "1"
   },
@@ -20,13 +20,13 @@
   "instanceNameFormat": "MSCRM Export Solution: $(solutionName)",
   "groups": [
     {
-      "name": "exportOptions",
-      "displayName": "Additional Export Options",
-      "isExpanded": false
-    },
-    {
       "name": "versioningOptions",
       "displayName": "Versioning Options",
+      "isExpanded": true
+    },
+    {
+      "name": "exportOptions",
+      "displayName": "Additional Export Options",
       "isExpanded": false
     }
   ],
@@ -200,14 +200,14 @@
       "label": "Versioning",
       "required": false,
       "defaultValue": "none",
-      "helpMarkDown": "Defines whether and how the solution version on the source environment should be updated.",
+      "helpMarkDown": "Defines whether and how the solution version on the source environment should be updated. When 'Build Number' or 'Release Name' is used the name/number has to end with '_x.x.x.x' e.g. '$(BuildDefinitionName)_5.0.0$(Rev:.r)'",
       "groupName": "versioningOptions",
       "options": {
           "none": "None",
           "buildnumber": "Build Number",
           "releasename": "Release Name",
           "manual": "Manual"
-      },
+      }
     },   
     {
       "name": "versionString",

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMSetVersion/task.json
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMSetVersion/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "10",
     "Minor": "0",
-    "Patch": "3"
+    "Patch": "4"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "MSCRM Set Version",


### PR DESCRIPTION
I made some changes to the MSCRMExportSolution task to allow more versioning options. I don't like the concept of only having a single option called "Update Version", which makes use of `Build.BuildNumber`. I know that there is a SetVersion task, but it would be really nice to do this in a single build step. Otherwise my pipeline will get really cluttered.

**Changes**

- Removed `UpdateVersion` checkbox
- Added `Versioning` radio button with the following options
  - "None": Does not change the Solution version
  - "Build Number": Uses `Build.BuildNumber`
  - "Release Name": Uses `Release.ReleaseName`
  - "Manual": The user can set the version string manually
- Added `VersionString` TextField, which is only visible when `Manual` is selected