### PR TITLE
Additional regions for Solution Checker task

### DIFF
--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMCheckSolution/task.json
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMCheckSolution/task.json
@@ -125,7 +125,12 @@
         "Canada": "Canada",
         "SouthAmerica": "South America",
         "UnitedKingdom": "United Kingdom",
-        "France": "France"
+        "France": "France",
+        "UnitedArabEmirates": "United Arab Emirates",
+        "USGovernment": "US Government",
+        "USGovernmentL4": "US Government L4",
+        "USGovernmentL5DoD": "US Government L5 (DoD)",
+        "China": "China"
       },
       "required": true,
       "helpMarkDown": "The region where the scan will be executed"


### PR DESCRIPTION
Added additional regions for Solution Checker task.

These regions are defined on the underlying PowerShell cmdlet as defined [here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powerapps.checker.powershell/invoke-powerappschecker?view=pa-ps-latest).