### PR TITLE
fix #284 use activateType instead of shareType

### DIFF
--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMActivateFlow/MSCRMActivateFlow.ps1
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMActivateFlow/MSCRMActivateFlow.ps1
@@ -55,7 +55,7 @@ $powerAppsAdminInfo = Get-MSCRMTool -toolName $powerAppsAdmin
 Require-ToolVersion -toolName $powerAppsAdmin -version $powerAppsAdminInfo.Version -minVersion '2.0.142'
 $powerAppsAdminPath = "$($powerAppsAdminInfo.Path)"
 
-if ($shareType -eq "Advanced")
+if ($activateType -eq "Advanced")
 {
 	$flowsToActivateJson = (Get-Content "$activateConfigFile" -Raw)
 }


### PR DESCRIPTION
There's an existing bug, raised in issues #284 this PR fixes that as the shareType variable is used instead of the activateType variable